### PR TITLE
Rider

### DIFF
--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -5,14 +5,14 @@ title: Development
 
 This is the developer docs for NetDaemon project. If you are looking for documentation how to make apps to control your home, please see [the docs here](https://netdaemon.xyz).
 
-In the developer pages you find useful information if you want to start contributing to NetDaemon project. 
+In the developer pages you find useful information if you want to start contributing to NetDaemon project.
 
 Thank you for considering contributing to this projects. This is most welcome!
 
 ## Get things going
 
 1. Fork and clone your copy of the netdaemon/netdaemon project
-2. Get it up and running and debugging in your prefered development environment. VSCode and Visual Studio is the supported for now. Please see specific docs for each of the development tool
+2. Get it up and running and debugging in your prefered development environment. VSCode, Visual Studio and JetBrains Rider are supported for now. Please see specific docs for each of the development tools
 3. Make sure you write tests. If you want to do a big design change, make Issue and describe your suggestion and ping the [discord group](https://discord.gg/K3xwfcX) to get the discussions going.
 4. Write tests that covers your added featureset or change the existing tests as needed. Do not exclude failing tests!
 5. Make PR and it will get reviewed and merged if tests is ok

--- a/docs/started/development.md
+++ b/docs/started/development.md
@@ -12,37 +12,57 @@ git clone https://github.com/net-daemon/netdaemon-app-template.git
 mv netdaemon-app-template netdaemon_apps
 cd netdaemon_apps
 ```
-## 2. Enable remote development in devcontainers
-If you are using Visual Studio Code, devcontainers are the preferred way to develop your apps. If you are running Visual Studio, skip this step. This also requires docker to be installed.
+## 2. Configure your development tool
+
+### 2.1 Visual Studio
+You should be all set, so skip to step 3
+
+### 2.2 Visual Studio Code
+If you are using Visual Studio Code, devcontainers are the preferred way to develop your apps. This also requires docker to be installed.
 
 1. Install [remote Development extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) in VSCode if you have not already.
 2. Open folder, the newly cloned template
-3. Run task: `Remote-Containers: Open Folder in Container`. Wait until it fully opened 
+3. Run task: `Remote-Containers: Open Folder in Container`. Wait until it fully opened
+
+### 2.3 JetBrains Rider
+Rider has supported debugging of ASP.Net Core apps from version 2018.2.
+
+Open the netdaemon_app folder in Rider and it should be able to build the projects immediately.
+A default execute and debug profile will be created however these will be executed as local processes.
+The preferred way to develop your app is to use devcontainers, which requires docker to be installed.
+To configure devcontainers, perform the following steps:
+
+1. Locate `Dockerfile` in the Solution Explorer window
+2. Right click and select `Debug Dockerfile`
+3. This will create a new profile called "DOCKERFILE"
+
+
+Ensure that the "DOCKERFILE" profile is selected in the toolbar and then `Run` and `Debug` will execute within the container.
 
 ## 3. Make configurations
-NetDaemon development environment needs to be configured to connect to Home Assistant.  Minimal config is: hostname/ip, port and access token. 
+NetDaemon development environment needs to be configured to connect to Home Assistant.  Minimal config is: hostname/ip, port and access token.
 
-1. Rename `_appsettings.json` to `appsettings.json`. 
+1. Rename `_appsettings.json` to `appsettings.json`.
 2. Edit the values in the appsetting `appsettings.json`. Following settings are mandatory:
-    - `Host`, the ip or hostname, (port defaults to 8123)
-    - `Token`, the long lived access token
+   - `Host`, the ip or hostname, (port defaults to 8123)
+   - `Token`, the long lived access token
 
 Example appsettings file
 ```json
 {
-    "Logging": {
-        "MinimumLevel": "info"    // debug, trace etc. can be set
-    },
-    "HomeAssistant": {
-        "Host": "your ip",        // ip or hostname to home assistant 
-        "Port": 8123,             // port of home assistant (default 8123)
-        "Ssl": false,             // true if use SSL to connect to Home Assistant
-        "Token": "Your token"     // Home Assistant security token
-    },
-    "NetDaemon": {
-        "AppSource": "./apps",     // path to apps directory
-        "GenerateEntities": false // generates entity helpers for V2 API on start
-    }
+   "Logging": {
+      "MinimumLevel": "info"    // debug, trace etc. can be set
+   },
+   "HomeAssistant": {
+      "Host": "your ip",        // ip or hostname to home assistant 
+      "Port": 8123,             // port of home assistant (default 8123)
+      "Ssl": false,             // true if use SSL to connect to Home Assistant
+      "Token": "Your token"     // Home Assistant security token
+   },
+   "NetDaemon": {
+      "AppSource": "./apps",     // path to apps directory
+      "GenerateEntities": false // generates entity helpers for V2 API on start
+   }
 }
 ```
 
@@ -56,3 +76,4 @@ Debug and run your apps and view log output for errors.
 After you have developed and tested your apps it is time to deploy and run the apps in the production environment. That's what we will look at next...
 
 
+~~~~

--- a/docs/started/get_started.md
+++ b/docs/started/get_started.md
@@ -6,11 +6,11 @@ title: Getting started
 Here is what you will need to start developing apps to automate your home with NetDaemon:
 
 - The hostname/ip-address and port of your Home Assistant instance
-- Have [git](https://git-scm.com/) installed to get the development template 
+- Have [git](https://git-scm.com/) installed to get the development template
 - Create an access token to use for authorization. The long lived access token is created under your profile in the Home Assistant GUI. Make sure the user account for this access token has Administrator privileges in Home Assistant
 - Have a .NET development environment. You can edit .cs files in any tool, but using a development environment is recommended
-    - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) or [Visual Studio Code](https://code.visualstudio.com)
-    - [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) installed (if running in devcontainer with VSCode, it is pre-installed)
-    - [Docker](https://www.docker.com/) installed if you want to use devcontainer in VSCode (recommended) 
+  - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/), [Visual Studio Code](https://code.visualstudio.com) or [JetBrains Rider](https://www.jetbrains.com/rider/)
+  - [.NET 6 SDK](https://dotnet.microsoft.com/download/dotnet/6.0) installed (if running in devcontainer with VSCode, it is pre-installed)
+  - [Docker](https://www.docker.com/) installed if you want to use devcontainer in VSCode (recommended)
 
 Now you have all you need to develop an app, lets just do that by moving to App development.


### PR DESCRIPTION
Updated docs to reference JetBrains Rider and explain how to configure Rider to build, execute and debug netdaemon within a container.
This entails adding references to Rider in the files that mention VS and VS Code and then breaking out the "development" page to have a section per app.

Execution and debugging has been verified with the current codebase on Rider 2021.3.1