### PR TITLE
Note to update HA when migrating, and fixed some v2 to v3 links

### DIFF
--- a/docs/v3/app_model/custom_logging.md
+++ b/docs/v3/app_model/custom_logging.md
@@ -2,7 +2,7 @@
 id: app_model_custom_logging
 title: Custom logging
 ---
-This page describes how to create and configure a custom logger. If you are happy with the standard logging described in the [Instance applications](/v2/app_model/instancing_apps.md) page then you don't need to read this page.
+This page describes how to create and configure a custom logger. If you are happy with the standard logging described in the [Instance applications](/v3/app_model/instancing_apps.md) page then you don't need to read this page.
 
 ### ILogger and Serilog
 The default Microsoft implementation of logging comes via the `Microsoft.Extensions.Logging.ILogger` interface that can be configured at application startup and then injected into subsequent classes.

--- a/docs/v3/app_model/instancing_apps.md
+++ b/docs/v3/app_model/instancing_apps.md
@@ -122,7 +122,7 @@ Note that the logs are cleared each time you restart the NetDaemon add-on (or th
 #### More advanced logging
 One of the goals of the NetDaemon template app is that it should work out of the box with minimal configuration. For that reason, the template ships with a "Default NetDaemon Logging Configurator", which supports all of the functionality described on this page, but nothing more.
 
-If you are familiar with Serilog or other .Net loggers and want to use more advanced techniques such as writing to log files or to remote log servers then please read the [Custom logging](v2/app_model/custom_logging.md) page, which shows how to create and configure a custom logger.
+If you are familiar with Serilog or other .Net loggers and want to use more advanced techniques such as writing to log files or to remote log servers then please read the [Custom logging](v3/app_model/custom_logging.md) page, which shows how to create and configure a custom logger.
 
 
 

--- a/docs/v3/app_model/moving_from_v2.md
+++ b/docs/v3/app_model/moving_from_v2.md
@@ -24,6 +24,8 @@ There are four main considerations when upgrading a new project to use v3 _(befo
 1. Change `GlobalUsings.cs` to refer to the new namespace
 1. Update `appSettings.json` to reflect a change in config
 
+After you have tested your project locally you will need to update your NetDaemon install on Home Assistant to v3.
+
 #### Update program.cs
 Refer to your project's `program.cs` and check the main application startup block. You will likely have a section that looks like this:
 
@@ -131,3 +133,12 @@ V3 variant:
   },
   // ...
 ```
+
+
+#### Update the version of NetDaemon  in Home Assistant
+
+If you still have v2 of NetDaemon installed inside Home Assistant ("HA") then that will not be able to run your v3 apps. You should remove the v2 install from HA first, then install the v3 version.
+
+After you have done so remember to check the configuration (the default config path changed from `/config/netdaemon` to `/config/netdaemon3`) and re-deploy your apps project to it, then restart NetDaemon and check the logs.
+
+You can find the [installation instructions here](v3/started/installation.md)


### PR DESCRIPTION
Forgot to mention that when local dev is complete you then need to remember to update the HA install of netdaemon from v2 to v3.
Also fixed a couple of links in the v3 docs that were point back into v2 versions of their pages.