### PR TITLE
Updates for mqtt entity manager changes

### DIFF
--- a/docs/v3/extensions/mqttEntityManager.md
+++ b/docs/v3/extensions/mqttEntityManager.md
@@ -136,7 +136,7 @@ You can use `additionalConfig` to supply additional parameters that might be req
 
 ### Setting the state of an entity
 
-Use the `SetState()` method to set an entity's state:
+Use the `SetStateAsync()` method to set an entity's state:
 
 ```csharp
 Task SetStateAsync(string entityId, string state);
@@ -149,7 +149,7 @@ The arguments are:
 
 ### Setting attributes on an entity
 
-Use the `SetAttributes()` method to set an entity's state:
+Use the `SetAttributesAsync()` method to set an entity's state:
 
 ```csharp
 Task SetAttributesAsync(string entityId, object attributes);
@@ -157,7 +157,7 @@ Task SetAttributesAsync(string entityId, object attributes);
 
 The arguments are:
  * `entityId` the "domain.identifier" format entity ID supplied in the `CreateAsync()` method
- * `attributes` a concrete or anonymouse object that can be serialized to json
+ * `attributes` a concrete or anonymous object that can be serialized to json
 
 
 
@@ -193,7 +193,7 @@ await entityManager.SetAvailabilityAsync("domain.sensor", "down").ConfigureAwait
 ```
 
 
-Please carefully consider whether you need to use availability on an entity - if you enable it then it becomes your responsibility to ensure that the availability is set correctly before attempting to read or update its state or configuration. An entity that is marked unavailable is... _unavailable_!
+Please carefully consider whether you need to use availability on an entity - if you enable it then it becomes your responsibility to ensure that the availability is set correctly before attempting to read or update its state or configuration. An entity that is marked unavailable is... _not available_!
 
 
 ### Removing entities
@@ -243,7 +243,7 @@ await _entityManager.CreateAsync("switch.kitchen_lights",
 
 **A humidity sensor with availability and custom unit-of-measurement**
 
-This example creates a sensor that uses "up" and "down" to mark its availability, and records the level of rain in terms of milimetres per hour. It takes advantage of the Availability payloads and a custom additional-config.
+This example creates a sensor that uses "up" and "down" to mark its availability, and records the level of rain in terms of milimetres per hour. It takes advantage of the Availability payloads, a specific device class ("humidity") and a custom additional-config.
 
 Finally, we set the sensor as being available and record three different measures.
 

--- a/docs/v3/extensions/mqttEntityManager.md
+++ b/docs/v3/extensions/mqttEntityManager.md
@@ -84,14 +84,19 @@ class MyApp(IMqttEntityManager entityManager)
 
 ## Entity Management API
 
-The extension currently offers three methods:
+The extension currently offers five methods:
 
 1. `CreateAsync(..)`, which allows you to create an entity in Home Assistant
-1. `UpdateAsync(..)` allows you to change an entity state and/or set its attributes
+1. `SetStateAsync(...)` sets the state of an entity
+1. `SetAttributesAsync(...)` sets a collection of attributes on an entity
+1. `SetAvailabilityAsync(...)` sets the availability of an entity
 1. `RemoveAsync(..)` allows you to remove an entity that has been created through this extension
 
 
-Each of these methods operates on an `entityId`, which is a standard Home Assistant identifier of the format "{domain}.{identifier}", for example "sensor.kitchen_temperature".
+In addition, the extension has a single property `QualityOfServiceLevel` which allows you to set the QoS level of the MQTT message that will be transmitted. See [this article](https://www.hivemq.com/blog/mqtt-essentials-part-6-mqtt-quality-of-service-levels/) for more information.
+
+
+Each of the methods operates on an `entityId`, which is a standard Home Assistant identifier of the format "{domain}.{identifier}", for example "sensor.kitchen_temperature".
 When you create an entity you should strive to use a unique identifier for each domain.
 
 
@@ -104,7 +109,7 @@ Please do bear in mind that the extension is using MQTT to create entities and s
 To create an entity you will call the following method:
 
 ```csharp
-Task CreateAsync(string entityId, EntityCreationOptions? options = null);
+Task CreateAsync(string entityId, EntityCreationOptions? options = null, object? additionalConfig = null);
 ```
 
 The only mandatory argument is the `entityId`, which is of the format "domain.identifier" - see the previous section for more information. Note that, depending on the domain, you may need to supply additional parameters - see the [Home Assistant Entity documentation](https://developers.home-assistant.io/docs/core/entity/) for specific details.
@@ -118,20 +123,77 @@ The optional `EntityCreationOptions` allows you to override the following parame
 |UniqueId|string|A unique identifier for the entity across the MQTT namespace|Combination of domain and identifier|
 |Name|string|A friendly name that is displayed in the HA user interface|Identifier part of `entityId`|
 |Persist|bool|Whether the entity should persist over HA restarts|`true`|
+|PayloadAvailable|string|The payload that defines an entity is available|`null`|
+|PayloadNotAvailable|string|The payload that defines an entity is not available|`null`|
+
+See the section below for more information on working with entity Availability.
+
+As well as the `EntityCreationOptions` you can suppy additional configuration via the `additionalConfig` argument. This is any kind of object that can be serialized to json and its contents are sent as part of the payload when creating the entity.
+
+You can use `additionalConfig` to supply additional parameters that might be required by some device classes that do not have corresponding properties in the `EntityCreationOptions` class. See the examples below for more information. 
 
 
-### Updating entities: state and attributes
 
-Use the `UpdateAsync()` method to set state and/or update attributes:
+### Setting the state of an entity
+
+Use the `SetState()` method to set an entity's state:
 
 ```csharp
-Task UpdateAsync(string entityId, string? state, object? attributes = null);
+Task SetStateAsync(string entityId, string state);
 ```
 
 The arguments are:
  * `entityId` the "domain.identifier" format entity ID supplied in the `CreateAsync()` method
- * `state` optional new desired state of the entity
- * `attributes` an optional collection of "key=value" attributes - this can be a concrete or anonymous object
+ * `state` any string value, including a blank string
+
+
+### Setting attributes on an entity
+
+Use the `SetAttributes()` method to set an entity's state:
+
+```csharp
+Task SetAttributesAsync(string entityId, object attributes);
+```
+
+The arguments are:
+ * `entityId` the "domain.identifier" format entity ID supplied in the `CreateAsync()` method
+ * `attributes` a concrete or anonymouse object that can be serialized to json
+
+
+
+### Working with entity availability
+
+When you create an entity without specifying availability payloads it is assumed to be permanently available. This can be helpful when you are using the entity to store state or attributes that you will use in other automations as you don't need to worry about marking it *available* before use.
+
+
+On the other hand, if you are using an entity as they were originally intended (i.e. to represent state of a physical device or sensor) then you may want to set it available and unavailable depending on the state of the hardware or device service.
+
+This is easy to configure - all you need to do is specify the payloads that mark it as available and unavailable when you create it, then call the `SetAvailabilityAsync()` to set it's availability with one of these payloads.
+To do this, set both the `PayloadAvailable` and `PayloadNotAvailable` properties on the `EntityCreationOptions` when you create the entity. For example:
+
+
+```csharp
+await entityManager.CreateAsync("domain.sensor", 
+   new EntityCreationOptions(PayloadAvailable: "up", PayloadNotAvailable: "down"))
+   .ConfigureAwait(false);
+```
+
+
+This configures the entity to have an _availability_ state, which you will set by passing it one of the two payloads you just defined. To set the availability, use this method:
+
+```csharp
+Task SetAvailabilityAsync(string entityId, string availability);
+```
+
+Using the above example, we can toggle a device to be available and then unavailable like this:
+
+```csharp
+await entityManager.SetAvailabilityAsync("domain.sensor", "up").ConfigureAwait(false);
+await entityManager.SetAvailabilityAsync("domain.sensor", "down").ConfigureAwait(false);
+```
+
+
+Please carefully consider whether you need to use availability on an entity - if you enable it then it becomes your responsibility to ensure that the availability is set correctly before attempting to read or update its state or configuration. An entity that is marked unavailable is... _unavailable_!
 
 
 ### Removing entities
@@ -148,6 +210,7 @@ The `entityId` argument has the same format as in the previous methods.
 When creating entities ensure
 - that the domain is provided in [Home Assistant style](https://developers.home-assistant.io/docs/core/entity/) for example `binary_sensor`
 - that your device class is valid for the given domain, for example see [Binary Sensor Device Classes](https://developers.home-assistant.io/docs/core/entity/binary-sensor?_highlight=device&_highlight=class#available-device-classes) Home Assistant docs
+
 
 ## Examples
 In the NetDaemon project template there is an example that demonstrates the functionality of the Entity Manager at `\dev\DebugHost\apps\Extensions\MqttEntityManagerApp.cs`
@@ -178,11 +241,28 @@ await _entityManager.CreateAsync("switch.kitchen_lights",
 ```
 
 
-**Change state of a sensor, and set an "updated" attribute to right now**
+**A humidity sensor with availability and custom unit-of-measurement**
+
+This example creates a sensor that uses "up" and "down" to mark its availability, and records the level of rain in terms of milimetres per hour. It takes advantage of the Availability payloads and a custom additional-config.
+
+Finally, we set the sensor as being available and record three different measures.
 
 ```csharp
-await _entityManager.UpdateAsync("sensor.my_id", "shiny", new { updated = DateTime.UtcNow })
-   .ConfigureAwait(false);
+var rainNexthour4Id = "sensor.rain_nexthour4";
+await _entityManager.CreateAsync(rainNexthour4Id, new EntityCreationOptions(
+  Name: "Rain Next Hour4",
+  DeviceClass: "humidity",
+  PayloadAvailable: "up",
+  PayloadNotAvailable: "down"
+  ),
+new { 
+  unit_of_measurement = "mm/h" }
+).ConfigureAwait(false);
+
+await _entityManager.SetAvailabilityAsync(rainNexthour4Id, "up").ConfigureAwait(false);
+await _entityManager.SetStateAsync(rainNexthour4Id, "11").ConfigureAwait(false);
+await _entityManager.SetStateAsync(rainNexthour4Id, "7").ConfigureAwait(false);
+await _entityManager.SetStateAsync(rainNexthour4Id, "1").ConfigureAwait(false);
 ```
 
 **Remove an entity**


### PR DESCRIPTION
Documentation updates to reflect the changed methods (`CreateAsync()`) and new methods (`SetStateAsync()`, `SetAttributesAsync()` and `SetAvailabilityAsync()` from PR 677 on netdaemon-core.

Also an explanation of what _availability_ is and how to configure it.

Updated examples.