### PR TITLE
Fix Docs: Debian 10 does not support the .NET 8 

### DIFF
--- a/docs/user/started/development.md
+++ b/docs/user/started/development.md
@@ -104,7 +104,7 @@ Ensure that the "DOCKERFILE" profile is selected in the toolbar and then `Run` a
    init_commands:
      - >-
        wget
-       https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb
+       https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb
        -O packages-microsoft-prod.deb
      - dpkg -i packages-microsoft-prod.deb
      - rm packages-microsoft-prod.deb


### PR DESCRIPTION
Hi,

I'm unable to configure the Studio Code Server Addon using the documentation since Debian 10 does not support the .NET 8 SDK. I'm getting the following error: `E: Unable to locate package dotnet-sdk-8.0
E: Couldn't find any package by glob 'dotnet-sdk-8.0' E: Couldn't find any package by regex 'dotnet-sdk-8.0' [19:21:02] FATAL: Failed executing init command: apt-get install -y dotnet-sdk-8.0`

As noted, only Debian 11 and above support .NET 8 (see https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian). 

I’ve submitted a small PR to update the documentation accordingly.