### PR TITLE
Update publish_script.md + increased laziness

### DIFF
--- a/docs/user/tutorials/publish_script.md
+++ b/docs/user/tutorials/publish_script.md
@@ -21,35 +21,40 @@ Write an PowerShell script that deploys your apps to Home Assistant with the fol
 
 After installing Samba share, please make sure that you can access your Home Assistant share from your machine:
 1. Press Windows + R to open the Run dialog
-2. In the Open Textbox write \\homeassistant.local\ (adapt if you use a different host name)
+2. In the Open Textbox write \\homeassistant.local\ (adapt if you use a different host name or use the ip adress)
 3. You will be prompted to enter User name and Password. Provide your User and Password from your Samba share configuration. Don't forget to tick "Remember my credentials".
 
 The Home Assistant PowerShell Module uses the IP address of Home Assistant to start/stop the addons. It's a anyway a good idea to give a fix IP address to your Home Assistant system.
 
 ## The Script
 
-- Create a Powershell file like publish.ps1.
+- Create a Powershell file like publish.ps1 in the same folder as your appsettings.json is located.
 - Create a subfolder "Home-Assistant" and copy the two files from the PowerShell Module into it.
 
 ```powershell
-$slug = 'c6a2317c_netdaemon5'        # the slug can be found in the url of the browser when navigating to the NetDaemon addon
-$json = '{"addon": "' + $slug + '"}'   
-$ip   = "192.168.0.44"                 # adapt to your IP address
-$port = 8123                           # change if your use another port
+$settings = (Get-Content appsettings.json | ConvertFrom-Json)
 
-$token = "Long-Lived Access Token"     # generate one here http://homeassistant.local:8123/profile 
+#CHANGE ME
+$slug = 'c6a2317c_netdaemon5' # the slug can be found in the url of the browser when navigating to the NetDaemon addon
+
+$version = $slug.Split('_')[-1] # adapt if you are not using the default foldername for the addon
+$json = '{"addon": "' + $slug + '"}'   
+$ip   = $settings.HomeAssistant.Host               
+$port = $settings.HomeAssistant.Port                           
+
+$token = $settings.HomeAssistant.Token  
 
 # Point to the HA PowerSHell Module
 Unblock-File .\Home-Assistant\Home-Assistant.psd1
 Unblock-File .\Home-Assistant\Home-Assistant.psm1
 Import-Module .\Home-Assistant
-
+  
 New-HomeAssistantSession -ip  $ip -port $port -token $token
 
-Invoke-HomeAssistantService -service HASSIO.ADDON_STOP -json $json
+Invoke-HomeAssistantService -service hassio.addon_stop -json $json
 
-Remove-Item -Recurse -Force \\homeassistant.local\config\netdaemon3\*
-dotnet publish -c Release HomeAssistant.csproj -o \\homeassistant.local\config\netdaemon3
+Remove-Item -Recurse -Force \\$ip\config\$version\*
+dotnet publish -c Release HomeAssistant.csproj -o \\$ip\config\$version
 
-Invoke-HomeAssistantService -service HASSIO.ADDON_START -json $json
+Invoke-HomeAssistantService -service hassio.addon_start -json $json
 ```


### PR DESCRIPTION
The publish script still references the folder for version 3.
While editing this I asked myself why do I even enter another access token and ip info to this script if i can just use the appsettings where I have that configured anyways for the codegen.