### PR TITLE
Refresh homepage visuals and live GitHub stats and new start page

### DIFF
--- a/docs/user/started/get_started.md
+++ b/docs/user/started/get_started.md
@@ -3,58 +3,47 @@ id: get_started
 title: Getting started with NetDaemon
 ---
 
-# Getting started
+# Getting started with NetDaemon
 
 This guide walks you through setting up your development environment for
 building NetDaemon apps.
 
 ## Prerequisites
 
-- Dotnet 10 SDK
-- Development environment
-- A Home Assistant long lived authorization token
+- .NET 10 SDK
+- A development environment such as Visual Studio, Visual Studio Code, or Rider
+- A Home Assistant instance
+- A Home Assistant long-lived access token
 - Git (optional)
 - Docker (optional)
 
-## NetDaemon development workflow
+## 1. Install the NetDaemon templates
 
-The following workflow is the recommended approach
-for developing and deploying NetDaemon:
+Install the NetDaemon .NET templates so you can scaffold a new project:
 
-1. Install the NetDaemon CLI tools to access the project template.
-2. Develop, build, compile, and test your NetDaemon apps locally using your preferred development environment.
-3. Publish your project.
-4. Deploy your project using one of the following options:
-    - NetDaemon Home Assistant add-on
-    - NetDaemon pre-built Docker container
-    - Your own Docker container
-
-### Install the NetDaemon .NET CLI tool and creating a project
-
-First, install the NetDaemon .NET CLI tool:
-
-```bash
+```bash title="Install templates"
 dotnet new --install NetDaemon.Templates.Project
 ```
 
-Once installed, create a new project using the template:
+## 2. Create a new project
 
-```csharp
-mkdir NetDaemonApps // Your project folder name
+Create a new folder and scaffold your first NetDaemon app:
+
+```bash title="Create a project"
+mkdir NetDaemonApps
 cd NetDaemonApps
 dotnet new nd-project
 ```
 
-*There is an deployment option where you use the source code
-to deploy NetDaemon apps, we do not recommend using it but see
-[souce deployment docs](development_source_deploy.md)
-for details*
+:::tip
+Run `dotnet new list netdaemon` to see the available NetDaemon templates.
+:::
 
 We assume you are familiar with your development environment,
 but for additional guidance and tips, see the
 [development tools tips & tricks page](development_tools.md).
 
-### Configuring NetDaemon appsettings.json
+## 3. Configure Home Assistant
 
 NetDaemon development environment needs to be configured to
 connect to Home Assistant.
@@ -67,7 +56,7 @@ Edit the values in the `appsettings.json`. The following settings are mandatory:
 
 Example `appsettings.json` file:
 
-```json
+```json title="appsettings.json"
 {
     "Logging": {
         "LogLevel": {
@@ -88,7 +77,7 @@ Example `appsettings.json` file:
     "CodeGeneration": {
         "Namespace": "HomeAssistantGenerated",
         "OutputFile": "HomeAssistantGenerated.cs",
-        "UseAttributeBaseClasses" : "false"
+        "UseAttributeBaseClasses": "false"
     }
 }
 ```
@@ -98,41 +87,54 @@ We recommend creating a development-specific configuration file named
 `appsettings.development.json`, which is automatically excluded from Git.
 This prevents accidentally exposing your secret token if you use an
 external git repository like GitHub. Remember to remove sensitive data
-from `appsettings.json` before push to remote repository!
+from `appsettings.json` before push to remote repository.
 :::
 
 :::tip
-When running your app from the console (e.g., `dotnet run --project "PATH_TO_YOUR_PROJECT"`), ensure an appsettings.json file is in the same directory. Without it, the NetDaemon Runtime will start but won’t connect to Home Assistant, and your apps won’t load.
+When running your app from the console, ensure an `appsettings.json` file is
+in the same directory. Without it, the NetDaemon Runtime will start but will
+not connect to Home Assistant, and your apps will not load.
 :::
 
-## Development and debugging NetDaemon apps
+## 4. Run and debug your project
 
 Once configured, you can begin developing your NetDaemon applications.
 The project template includes example apps to help you get started with
 development and testing.
 
-Run and debug your applications while monitoring log output for errors.
+Run the project from your project folder:
+
+```bash title="Run NetDaemon"
+dotnet run
+```
+
+Debug your applications while monitoring log output for errors.
 
 For a more powerful and convenient way to interact with Home Assistant
-entities and services, we recommend using the [code generator](../hass_model/hass_model_codegen.md)
-code generator to generate C# classes.
+entities and services, we recommend using the
+[code generator](../hass_model/hass_model_codegen.md) to generate C# classes.
 
-## Deploy NetDaemon apps
+## 5. Deploy NetDaemon apps
 
-Use `dotnet publish -c Release -o [your output directory]`
+Use `dotnet publish -c Release -o [your output directory]`.
 Then, copy all contents from `[your_output_directory]` to the appropriate
 location on your Home Assistant host:
 
 - If using the NetDaemon add-on: `/config/netdaemon6`
 - If using another hosting option: Copy to your chosen destination folder
 
-For more details on different deployment options, see the [Installation Documentation](user/started/installation.md)
+For more details on different deployment options, see the
+[installation documentation](installation.md).
+
+There is a deployment option where you use the source code to deploy
+NetDaemon apps. We do not recommend using it for most users, but see the
+[source deployment docs](development_source_deploy.md) for details.
 
 ## Keep your dependencies and tools up-to-date
 
 The template project includes a PowerShell script to update NetDaemon
 and all dependent packages to their latest versions:
 
-```bash
+```powershell title="Update dependencies"
 update_all_dependencies.ps1
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,6 +21,11 @@ module.exports = {
   },
   themes: ['@docusaurus/theme-mermaid'],
   themeConfig: {
+    colorMode: {
+      defaultMode: 'dark',
+      disableSwitch: false,
+      respectPrefersColorScheme: false,
+    },
     algolia: {
       // The application ID provided by Algolia
       appId: 'BD12ZZ1ACW',
@@ -67,16 +72,22 @@ module.exports = {
         position: 'left',
       },
       {
-        to: 'docs/developer',
-        activeBasePath: 'docs',
+        to: '/docs/developer',
+        activeBasePath: 'docs/developer',
         label: 'Developer',
         position: 'left',
       },
       // { to: 'blog', label: 'Blog', position: 'left' },
       {
-        href: 'https://github.com/net-daemon/docs',
+        href: 'https://github.com/net-daemon/netdaemon',
         label: 'GitHub',
         position: 'right',
+      },
+      {
+        to: '/docs/user/started/get_started/',
+        label: 'Get Started',
+        position: 'right',
+        className: 'navbar-get-started',
       },
     ],
   },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,26 +1,378 @@
 /* stylelint-disable docusaurus/copyright-header */
-/**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
- */
 
-/* You can override the default Infima variables here. */
 :root {
-  --ifm-color-primary: #3578e5;
-  --ifm-color-primary-dark: #1d68e1;
-  --ifm-color-primary-darker: #1b62d4;
-  --ifm-color-primary-darkest: #1751af;
-  --ifm-color-primary-light: #4e89e8;
-  --ifm-color-primary-lighter: #5a91ea;
-  --ifm-color-primary-lightest: #80aaef;
-
-  --ifm-color-secondary: #1bd4d4;
-  --ifm-color-info: #70bdd7;
-  --ifm-color-warning: #c18802;
-  --ifm-color-danger: #d78a70;
-  --ifm-color-gray-900: #292929;
-  --ifm-color-success: #70d7a7;
-  --ifm-alert-border-radius: 4px;
+  --ifm-color-primary: #258bff;
+  --ifm-color-primary-dark: #0d7cff;
+  --ifm-color-primary-darker: #0070f2;
+  --ifm-color-primary-darkest: #005ac2;
+  --ifm-color-primary-light: #43a2ff;
+  --ifm-color-primary-lighter: #5eb0ff;
+  --ifm-color-primary-lightest: #94cbff;
+  --ifm-color-secondary: #7d5cff;
+  --ifm-color-info: #46c7ff;
+  --ifm-color-warning: #f0b858;
+  --ifm-color-danger: #ff7b85;
+  --ifm-color-success: #56e39f;
+  --ifm-alert-border-radius: 8px;
+  --ifm-background-color: #f7f9fd;
+  --ifm-font-family-base:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  --ifm-heading-font-weight: 800;
+  --ifm-navbar-height: 4.8rem;
+  --ifm-global-radius: 8px;
+  --ifm-code-border-radius: 6px;
+  --nd-bg: #f7f9fd;
+  --nd-surface: #ffffff;
+  --nd-surface-strong: #eef3fb;
+  --nd-border: rgba(40, 58, 94, 0.14);
+  --nd-text: #0e1728;
+  --nd-text-muted: #4f5d75;
+  --nd-text-soft: #6d7890;
+  --nd-accent: #258bff;
+  --nd-accent-strong: #7d5cff;
+  --nd-code-bg: #0b1423;
 }
 
+[data-theme='dark'] {
+  --ifm-background-color: #030813;
+  --ifm-background-surface-color: #071224;
+  --ifm-navbar-background-color: rgba(2, 7, 18, 0.9);
+  --ifm-footer-background-color: #030813;
+  --ifm-color-content: #d9e3f7;
+  --ifm-color-content-secondary: #aeb9cd;
+  --ifm-menu-color: #b5bfd2;
+  --ifm-toc-link-color: #aeb9cd;
+  --ifm-code-background: rgba(117, 80, 255, 0.14);
+  --ifm-pre-background: #07101e;
+  --ifm-table-border-color: rgba(145, 166, 207, 0.18);
+  --nd-bg: #030813;
+  --nd-surface: rgba(8, 17, 35, 0.88);
+  --nd-surface-strong: rgba(18, 32, 57, 0.92);
+  --nd-border: rgba(145, 166, 207, 0.18);
+  --nd-text: #f5f8ff;
+  --nd-text-muted: #c2cade;
+  --nd-text-soft: #96a2bb;
+  --nd-accent: #2aa7ff;
+  --nd-accent-strong: #805cff;
+  --nd-code-bg: #07101e;
+}
+
+html,
+body {
+  background: var(--nd-bg);
+}
+
+body {
+  letter-spacing: 0;
+}
+
+a {
+  text-underline-offset: 0.2em;
+}
+
+.navbar {
+  border-bottom: 1px solid var(--nd-border);
+  box-shadow: none;
+  backdrop-filter: blur(18px);
+}
+
+.navbar__inner {
+  margin: 0 auto;
+  max-width: 1400px;
+}
+
+.navbar__brand {
+  gap: 0.75rem;
+  font-size: 1.45rem;
+  font-weight: 800;
+}
+
+.navbar__logo {
+  height: 2.8rem;
+}
+
+.navbar__item {
+  font-weight: 650;
+}
+
+.navbar__link {
+  border-radius: 8px;
+}
+
+.navbar__link--active {
+  color: var(--nd-accent);
+}
+
+.navbar__link--active::after {
+  display: block;
+  height: 2px;
+  margin: 0.25rem auto -0.45rem;
+  content: '';
+  background: linear-gradient(90deg, var(--nd-accent), var(--nd-accent-strong));
+  border-radius: 999px;
+  box-shadow: 0 0 18px rgba(42, 167, 255, 0.72);
+}
+
+.navbar-get-started {
+  padding: 0.65rem 1.1rem;
+  margin-left: 0.5rem;
+  color: #fff !important;
+  background: linear-gradient(135deg, #1687ff, #7648ff);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(76, 88, 255, 0.36);
+}
+
+.navbar-get-started::after {
+  display: none;
+}
+
+body.homepage-dark-navbar .navbar {
+  background: rgba(2, 7, 18, 0.92);
+}
+
+body.homepage-dark-navbar .navbar__title,
+body.homepage-dark-navbar .navbar__link {
+  color: #f5f8ff;
+}
+
+body.homepage-dark-navbar .navbar__link:hover,
+body.homepage-dark-navbar .navbar__link--active {
+  color: #2aa7ff;
+}
+
+body.homepage-dark-navbar [class*='colorModeToggle'] button {
+  color: #f5f8ff;
+}
+
+body.homepage-dark-navbar [class*='colorModeToggle'] {
+  display: none;
+}
+
+body.homepage-dark-navbar .DocSearch-Button {
+  color: #96a2bb !important;
+  background: rgba(8, 17, 35, 0.88) !important;
+  border-color: rgba(145, 166, 207, 0.18) !important;
+}
+
+body.homepage-dark-navbar .DocSearch-Button:hover {
+  color: #f5f8ff !important;
+}
+
+.theme-doc-sidebar-container {
+  background:
+    radial-gradient(circle at 0 100%, rgba(111, 72, 255, 0.13), transparent 18rem),
+    var(--nd-bg);
+  border-right: 1px solid var(--nd-border) !important;
+}
+
+.theme-doc-sidebar-menu {
+  padding: 1rem 0.65rem 1.5rem !important;
+}
+
+.menu__list-item {
+  margin: 0.12rem 0;
+}
+
+.menu__link {
+  min-height: 2.4rem;
+  padding: 0.55rem 0.8rem;
+  color: var(--ifm-menu-color);
+  border-radius: 7px;
+}
+
+.menu__link:hover {
+  color: var(--nd-text);
+  background: rgba(41, 121, 255, 0.12);
+}
+
+.menu__link--active {
+  color: #10203a;
+  background:
+    linear-gradient(90deg, rgba(128, 92, 255, 0.28), rgba(33, 132, 255, 0.18)),
+    rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(33, 132, 255, 0.35);
+  box-shadow: inset 3px 0 0 #8b5cff, 0 10px 22px rgba(41, 121, 255, 0.1);
+}
+
+[data-theme='dark'] .menu__link--active {
+  color: #fff;
+  background:
+    linear-gradient(90deg, rgba(128, 92, 255, 0.55), rgba(33, 132, 255, 0.28)),
+    rgba(35, 80, 154, 0.28);
+  border-color: rgba(70, 170, 255, 0.45);
+  box-shadow: inset 3px 0 0 #8b5cff, 0 0 22px rgba(41, 121, 255, 0.15);
+}
+
+.theme-doc-toc-desktop {
+  border-left: 1px solid var(--nd-border);
+}
+
+.table-of-contents {
+  padding: 1.2rem 0 1.2rem 1.35rem;
+  font-size: 0.9rem;
+}
+
+.table-of-contents__link {
+  color: var(--nd-text-soft);
+}
+
+.table-of-contents__link--active,
+.table-of-contents__link:hover {
+  color: var(--nd-accent);
+}
+
+.main-wrapper {
+  background:
+    radial-gradient(circle at 78% 12%, rgba(107, 75, 255, 0.08), transparent 26rem),
+    radial-gradient(circle at 22% 8%, rgba(42, 167, 255, 0.08), transparent 22rem),
+    var(--nd-bg);
+}
+
+.theme-doc-markdown {
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.theme-doc-markdown h1 {
+  margin-top: 0.85rem;
+  font-size: clamp(2.4rem, 5vw, 3.5rem);
+  line-height: 1.12;
+  letter-spacing: 0;
+}
+
+.theme-doc-markdown h2 {
+  padding-top: 0.8rem;
+  margin-top: 2.1rem;
+  font-size: 1.75rem;
+  border-top: 1px solid var(--nd-border);
+}
+
+.theme-doc-markdown h3 {
+  margin-top: 1.6rem;
+}
+
+.breadcrumbs {
+  color: var(--nd-text-soft);
+  font-size: 0.88rem;
+}
+
+.breadcrumbs__link {
+  border-radius: 6px;
+}
+
+.breadcrumbs__item--active .breadcrumbs__link {
+  color: var(--nd-accent);
+}
+
+.theme-doc-markdown img {
+  border: 1px solid var(--nd-border);
+  border-radius: 8px;
+  box-shadow: 0 16px 38px rgba(0, 0, 0, 0.18);
+}
+
+.theme-code-block,
+div[class*='codeBlockContainer'] {
+  background: var(--nd-code-bg) !important;
+  border: 1px solid var(--nd-border);
+  border-radius: 8px;
+  box-shadow: 0 20px 44px rgba(0, 0, 0, 0.18);
+}
+
+.theme-code-block pre,
+div[class*='codeBlockContent'] pre {
+  font-size: 0.94rem;
+}
+
+.theme-code-block button,
+div[class*='codeBlockTitle'] {
+  border-color: var(--nd-border) !important;
+}
+
+.alert {
+  background:
+    linear-gradient(135deg, rgba(128, 92, 255, 0.14), rgba(42, 167, 255, 0.08)),
+    var(--nd-surface);
+  border: 1px solid var(--nd-border);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.12);
+}
+
+.alert--success {
+  --ifm-alert-border-color: rgba(86, 227, 159, 0.48);
+}
+
+.alert--info {
+  --ifm-alert-border-color: rgba(70, 199, 255, 0.5);
+}
+
+.alert--warning {
+  --ifm-alert-border-color: rgba(240, 184, 88, 0.55);
+}
+
+.pagination-nav__link {
+  background: var(--nd-surface);
+  border-color: var(--nd-border);
+  border-radius: 8px;
+}
+
+.pagination-nav__link:hover {
+  border-color: rgba(42, 167, 255, 0.55);
+  box-shadow: 0 16px 36px rgba(33, 132, 255, 0.14);
+}
+
+.DocSearch-Button {
+  height: 2.45rem !important;
+  color: var(--nd-text-soft) !important;
+  background: var(--nd-surface) !important;
+  border: 1px solid var(--nd-border) !important;
+  border-radius: 8px !important;
+}
+
+.DocSearch-Button:hover {
+  color: var(--nd-text) !important;
+  border-color: rgba(42, 167, 255, 0.45) !important;
+  box-shadow: none !important;
+}
+
+.DocSearch-Button-Key {
+  background: rgba(140, 157, 190, 0.16) !important;
+  box-shadow: none !important;
+}
+
+.footer {
+  border-top: 1px solid var(--nd-border);
+}
+
+@media screen and (min-width: 997px) {
+  .theme-doc-markdown {
+    max-width: 760px;
+  }
+}
+
+@media screen and (max-width: 996px) {
+  .navbar__items--right .navbar-get-started {
+    display: none;
+  }
+
+  .theme-doc-sidebar-container {
+    background: var(--nd-bg);
+  }
+}
+
+@media screen and (max-width: 640px) {
+  :root {
+    --ifm-navbar-height: 4.2rem;
+  }
+
+  .navbar__brand {
+    font-size: 1.15rem;
+  }
+
+  .navbar__logo {
+    height: 2.35rem;
+  }
+
+  .theme-doc-markdown h1 {
+    font-size: 2.35rem;
+  }
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -340,7 +340,53 @@ div[class*='codeBlockTitle'] {
 }
 
 .footer {
-  border-top: 1px solid var(--nd-border);
+  color: var(--nd-text-muted);
+  background:
+    radial-gradient(circle at 26% 0%, rgba(42, 167, 255, 0.11), transparent 24rem),
+    radial-gradient(circle at 72% 0%, rgba(128, 92, 255, 0.13), transparent 25rem),
+    linear-gradient(180deg, rgba(7, 18, 36, 0.98), #030813 78%);
+  border-top: 1px solid rgba(70, 170, 255, 0.22);
+  box-shadow: inset 0 1px 0 rgba(128, 92, 255, 0.18);
+}
+
+.footer.footer--dark {
+  --ifm-footer-background-color: transparent;
+  --ifm-footer-color: var(--nd-text-muted);
+  --ifm-footer-link-color: #8f7dff;
+  --ifm-footer-title-color: var(--nd-text);
+}
+
+.footer .container {
+  max-width: 1280px;
+}
+
+.footer__title {
+  color: var(--nd-text);
+  font-size: 0.95rem;
+}
+
+.footer__link-item {
+  color: #8f7dff;
+  transition: color 160ms ease;
+}
+
+.footer__link-item:hover {
+  color: #45c0ff;
+  text-decoration: none;
+}
+
+.footer__bottom {
+  color: var(--nd-text-soft);
+}
+
+.footer__copyright a {
+  color: #45c0ff;
+  font-weight: 650;
+}
+
+.footer__copyright a:hover {
+  color: #8f7dff;
+  text-decoration: none;
 }
 
 @media screen and (min-width: 997px) {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,108 +1,169 @@
-import React from 'react';
-import CodeBlock from '@theme/CodeBlock';
+import React, { useEffect } from 'react';
 import classnames from 'classnames';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 
+const codePreview = `using NetDaemon.HassModel;
+
+public class OfficeMotion : EntityBase
+{
+    [Entity]
+    private BinarySensor OfficeMotion { get; set; }
+
+    [Entity]
+    private Light Office { get; set; }
+
+    protected override void Init()
+    {
+        OfficeMotion.StateChanged()
+            .Where(state => state.New?.IsOn() == true)
+            .Throttle(TimeSpan.FromSeconds(1))
+            .Subscribe(_ => Office.TurnOn());
+    }
+}`;
+
 const features = [
   {
-    title: <>For the C# developer</>,
-    imageUrl: 'img/C_Sharp_logo.svg',
-    description: (
-      <>
-        With NetDaemon you can write your home automations in C# for Home Assistant using modern .NET design. NetDaemon is open source and will always be free!
-      </>
-    ),
+    icon: '</>',
+    title: 'Built for C# developers',
+    description:
+      'Write automations in C# with a rich API, modern .NET patterns, and tooling that feels familiar from the first project.',
   },
   {
-    title: <>Integrated with Home Assistant</>,
-    imageUrl: 'img/hass.png',
-    description: (
-      <>
-        Integrated with Home Assistant using websockets for maximum performance. Has advanced scheduling and a easy to use API.
-      </>
-    ),
+    image: 'img/hass.png',
+    title: 'Deep Home Assistant integration',
+    description:
+      'Use real-time events, entities, services, and state through fast websocket integration.',
   },
   {
-    title: <>Code generation</>,
-    Link: 'https://www.youtube.com/watch?v=OCej2TVdKQo',
-    codeBlock: `entities.BinarySensor.OfficeMotion
-    .StateChanges()
-    .Where(e => e.New.IsOn())
-    .Subscribe(_ =>
-      entities.Light.Office.TurnOn());`,
-    description: (
-      <>
-
-        All your entities and services can be generated for full intellisense experience.
-        <br /><Link to="https://www.youtube.com/watch?v=OCej2TVdKQo" target="_blank" rel="noopener noreferrer">Watch our introduction video!</Link>
-      </>
-    ),
+    icon: '=>',
+    title: 'Developer experience first',
+    description:
+      'Strong typing, IntelliSense, templates, and rapid local iteration help keep automations easy to maintain.',
   },
-
 ];
 
-function Feature({ imageUrl, title, description, codeBlock }) {
-  const imgUrl = useBaseUrl(imageUrl);
+const stats = [
+  { value: '2.1k', label: 'Stars' },
+  { value: '240', label: 'Forks' },
+  { value: '320+', label: 'Contributors' },
+];
+
+const uses = ['Home Automation', 'Smart Buildings', 'Integrations', 'Prototyping', 'Open Source'];
+
+function FeatureCard({ icon, image, title, description }) {
+  const imageUrl = image ? useBaseUrl(image) : null;
+
   return (
-    <div className={classnames('col col--4', styles.feature)}>
-      {imgUrl && !codeBlock &&(
-        <div className="text--center">
-          <img className={styles.featureImage} src={imgUrl} alt={title} />
-        </div>
-      )}
-      {codeBlock &&(
-        <CodeBlock language="cs">
-          {codeBlock}
-          </CodeBlock>
-      )}
-      <h3>{title}</h3>
-      <p>{description}</p>
+    <article className={styles.featureCard}>
+      <div className={styles.featureIcon}>
+        {imageUrl ? <img src={imageUrl} alt="" /> : <span>{icon}</span>}
+      </div>
+      <div>
+        <h3>{title}</h3>
+        <p>{description}</p>
+      </div>
+    </article>
+  );
+}
+
+function CodePanel() {
+  return (
+    <div className={styles.codeWrap} aria-label="NetDaemon C# automation example">
+      <div className={styles.languagePill}>C#</div>
+      <pre className={styles.codePanel}>
+        <code>{codePreview}</code>
+      </pre>
+      <div className={styles.homeAssistantBadge}>
+        <img src={useBaseUrl('img/hass.png')} alt="Home Assistant" />
+      </div>
     </div>
   );
 }
 
-function Home() {
-  const context = useDocusaurusContext();
-  const { siteConfig = {} } = context;
+export default function Home() {
+  const logoUrl = useBaseUrl('img/favicon.png');
+
+  useEffect(() => {
+    document.body.classList.add('homepage-dark-navbar');
+
+    return () => {
+      document.body.classList.remove('homepage-dark-navbar');
+    };
+  }, []);
+
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Home automations in c# for Home Assistant">
-      <header className={classnames('hero hero--primary', styles.heroBanner)}>
-        <div className="container">
-          <h1 className="hero__title">{siteConfig.title}</h1>
-          <p className="hero__subtitle">{siteConfig.tagline}</p>
-          <div className={styles.buttons}>
-            <Link
-              className={classnames(
-                'button button--outline button--secondary button--lg',
-                styles.getStarted,
-              )}
-              to={useBaseUrl('docs/user/started/get_started')}>
-              Get Started
-            </Link>
+      title="NetDaemon"
+      description="C# automation platform for Home Assistant">
+      <main className={styles.pageShell}>
+        <section className={styles.hero}>
+          <div className={styles.heroGlow} aria-hidden="true" />
+          <div className={styles.heroNavBrand}>
+            <img src={logoUrl} alt="" />
+            <span>NetDaemon</span>
           </div>
-        </div>
-      </header>
-      <main>
-        {features && features.length && (
-          <section className={styles.features}>
-            <div className="container">
-              <div className="row">
-                {features.map((props, idx) => (
-                  <Feature key={idx} {...props} />
-                ))}
+          <div className={styles.heroGrid}>
+            <div className={styles.heroContent}>
+              <span className={styles.badge}>Open source</span>
+              <h1>
+                Automate Home Assistant with <span>C#</span>
+              </h1>
+              <p className={styles.lede}>
+                NetDaemon is a modern C# automation platform for Home Assistant.
+                Powerful. Developer-friendly. Open source.
+              </p>
+              <div className={styles.heroActions}>
+                <Link className={classnames(styles.button, styles.primaryButton)} to="/docs/user/started/get_started/">
+                  Get Started <span aria-hidden="true">-&gt;</span>
+                </Link>
+                <Link className={classnames(styles.button, styles.secondaryButton)} to="/docs/user/">
+                  View Documentation <span aria-hidden="true">[]</span>
+                </Link>
               </div>
             </div>
-          </section>
-        )}
+            <CodePanel />
+          </div>
+        </section>
+
+        <section className={styles.features} aria-label="NetDaemon benefits">
+          {features.map((feature) => (
+            <FeatureCard key={feature.title} {...feature} />
+          ))}
+        </section>
+
+        <section className={styles.githubPanel} aria-label="GitHub community">
+          <div className={styles.githubIntro}>
+            <div className={styles.githubMark}>GH</div>
+            <div>
+              <h2>Open source on GitHub</h2>
+              <p>Join the community, contribute, and help make NetDaemon even better.</p>
+              <Link className={styles.githubButton} to="https://github.com/net-daemon/netdaemon">
+                View on GitHub
+              </Link>
+            </div>
+          </div>
+          <div className={styles.statsGrid}>
+            {stats.map((stat) => (
+              <div className={styles.stat} key={stat.label}>
+                <strong>{stat.value}</strong>
+                <span>{stat.label}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.useCases} aria-label="Common use cases">
+          <p>Trusted by Home Assistant enthusiasts and professionals</p>
+          <div>
+            {uses.map((use) => (
+              <span key={use}>{use}</span>
+            ))}
+          </div>
+        </section>
       </main>
     </Layout>
   );
 }
-
-export default Home;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import classnames from 'classnames';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
@@ -45,13 +45,65 @@ const features = [
   },
 ];
 
-const stats = [
-  { value: '2.1k', label: 'Stars' },
-  { value: '240', label: 'Forks' },
-  { value: '320+', label: 'Contributors' },
+const fallbackStats = [
+  { key: 'stars', value: 299, label: 'Stars' },
+  { key: 'forks', value: 80, label: 'Forks' },
+  { key: 'contributors', value: 48, label: 'Contributors' },
 ];
 
+const githubRepositoryUrl = 'https://api.github.com/repos/net-daemon/netdaemon';
+const githubContributorsUrl = `${githubRepositoryUrl}/contributors?per_page=1&anon=true`;
+
 const uses = ['Home Automation', 'Smart Buildings', 'Integrations', 'Prototyping', 'Open Source'];
+
+function formatStatValue(value) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat('en-US', {
+    notation: value >= 10000 ? 'compact' : 'standard',
+    maximumFractionDigits: 1,
+  }).format(value);
+}
+
+function getContributorCount(linkHeader) {
+  const lastPageMatch = linkHeader?.match(/[?&]page=(\d+)>;\s*rel="last"/);
+
+  if (!lastPageMatch) {
+    return null;
+  }
+
+  return Number.parseInt(lastPageMatch[1], 10);
+}
+
+async function fetchGithubStats(signal) {
+  const [repositoryResponse, contributorsResponse] = await Promise.all([
+    fetch(githubRepositoryUrl, { signal }),
+    fetch(githubContributorsUrl, { signal }),
+  ]);
+
+  if (!repositoryResponse.ok || !contributorsResponse.ok) {
+    throw new Error('Unable to load GitHub stats');
+  }
+
+  const repository = await repositoryResponse.json();
+  const contributorCount = getContributorCount(contributorsResponse.headers.get('Link'));
+
+  if (
+    !Number.isFinite(repository.stargazers_count) ||
+    !Number.isFinite(repository.forks_count) ||
+    !Number.isFinite(contributorCount)
+  ) {
+    throw new Error('GitHub stats response was incomplete');
+  }
+
+  return [
+    { key: 'stars', value: repository.stargazers_count, label: 'Stars' },
+    { key: 'forks', value: repository.forks_count, label: 'Forks' },
+    { key: 'contributors', value: contributorCount, label: 'Contributors' },
+  ];
+}
 
 function FeatureCard({ icon, image, title, description }) {
   const imageUrl = image ? useBaseUrl(image) : null;
@@ -85,12 +137,29 @@ function CodePanel() {
 
 export default function Home() {
   const logoUrl = useBaseUrl('img/favicon.png');
+  const [stats, setStats] = useState(fallbackStats);
 
   useEffect(() => {
     document.body.classList.add('homepage-dark-navbar');
 
     return () => {
       document.body.classList.remove('homepage-dark-navbar');
+    };
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetchGithubStats(controller.signal)
+      .then(setStats)
+      .catch((error) => {
+        if (error.name !== 'AbortError') {
+          setStats(fallbackStats);
+        }
+      });
+
+    return () => {
+      controller.abort();
     };
   }, []);
 
@@ -148,7 +217,7 @@ export default function Home() {
           <div className={styles.statsGrid}>
             {stats.map((stat) => (
               <div className={styles.stat} key={stat.label}>
-                <strong>{stat.value}</strong>
+                <strong>{formatStatValue(stat.value)}</strong>
                 <span>{stat.label}</span>
               </div>
             ))}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,24 +5,105 @@ import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import styles from './styles.module.css';
 
-const codePreview = `using NetDaemon.HassModel;
-
-public class OfficeMotion : EntityBase
-{
-    [Entity]
-    private BinarySensor OfficeMotion { get; set; }
-
-    [Entity]
-    private Light Office { get; set; }
-
-    protected override void Init()
-    {
-        OfficeMotion.StateChanged()
-            .Where(state => state.New?.IsOn() == true)
-            .Throttle(TimeSpan.FromSeconds(1))
-            .Subscribe(_ => Office.TurnOn());
-    }
-}`;
+const codePreview = [
+  [
+    { token: 'keyword', text: 'using' },
+    { text: ' ' },
+    { token: 'namespace', text: 'System' },
+    { text: ';' },
+  ],
+  [
+    { token: 'keyword', text: 'using' },
+    { text: ' ' },
+    { token: 'namespace', text: 'System.Reactive.Linq' },
+    { text: ';' },
+  ],
+  [
+    { token: 'keyword', text: 'using' },
+    { text: ' ' },
+    { token: 'namespace', text: 'NetDaemon.AppModel' },
+    { text: ';' },
+  ],
+  [
+    { token: 'keyword', text: 'using' },
+    { text: ' ' },
+    { token: 'namespace', text: 'NetDaemon.HassModel' },
+    { text: ';' },
+  ],
+  [
+    { token: 'keyword', text: 'using' },
+    { text: ' ' },
+    { token: 'namespace', text: 'HomeAssistantGenerated' },
+    { text: ';' },
+  ],
+  [],
+  [
+    { text: '[' },
+    { token: 'attribute', text: 'NetDaemonApp' },
+    { text: ']' },
+  ],
+  [
+    { token: 'keyword', text: 'public' },
+    { text: ' ' },
+    { token: 'keyword', text: 'class' },
+    { text: ' ' },
+    { token: 'type', text: 'ExampleAppHaContext' },
+  ],
+  [{ text: '{' }],
+  [
+    { text: '    ' },
+    { token: 'keyword', text: 'public' },
+    { text: ' ' },
+    { token: 'type', text: 'ExampleAppHaContext' },
+    { text: '(' },
+    { token: 'type', text: 'IHaContext' },
+    { text: ' ha)' },
+  ],
+  [{ text: '    {' }],
+  [
+    { text: '        ' },
+    { token: 'keyword', text: 'var' },
+    { text: ' entities = ' },
+    { token: 'keyword', text: 'new' },
+    { text: ' ' },
+    { token: 'type', text: 'Entities' },
+    { text: '(ha);' },
+  ],
+  [],
+  [
+    { text: '        entities.' },
+    { token: 'property', text: 'BinarySensor' },
+    { text: '.' },
+    { token: 'property', text: 'OfficeMotion' },
+  ],
+  [
+    { text: '            .' },
+    { token: 'method', text: 'StateChanges' },
+    { text: '()' },
+  ],
+  [
+    { text: '            .' },
+    { token: 'method', text: 'Where' },
+    { text: '(e => e.' },
+    { token: 'property', text: 'New' },
+    { text: '.' },
+    { token: 'method', text: 'IsOn' },
+    { text: '())' },
+  ],
+  [
+    { text: '            .' },
+    { token: 'method', text: 'Subscribe' },
+    { text: '(_ => entities.' },
+    { token: 'property', text: 'Light' },
+    { text: '.' },
+    { token: 'property', text: 'Office' },
+    { text: '.' },
+    { token: 'method', text: 'TurnOn' },
+    { text: '());' },
+  ],
+  [{ text: '    }' }],
+  [{ text: '}' }],
+];
 
 const features = [
   {
@@ -126,7 +207,17 @@ function CodePanel() {
     <div className={styles.codeWrap} aria-label="NetDaemon C# automation example">
       <div className={styles.languagePill}>C#</div>
       <pre className={styles.codePanel}>
-        <code>{codePreview}</code>
+        <code>
+          {codePreview.map((line, lineIndex) => (
+            <span className={styles.codeLine} key={lineIndex}>
+              {line.map((part, partIndex) => (
+                <span className={part.token ? styles[part.token] : undefined} key={partIndex}>
+                  {part.text}
+                </span>
+              ))}
+            </span>
+          ))}
+        </code>
       </pre>
       <div className={styles.homeAssistantBadge}>
         <img src={useBaseUrl('img/hass.png')} alt="Home Assistant" />

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -184,8 +184,8 @@
   margin: 0;
   overflow: auto;
   color: #e9f2ff;
-  font-size: 0.92rem;
-  line-height: 1.75;
+  font-size: 0.78rem;
+  line-height: 1.65;
   background:
     linear-gradient(180deg, rgba(11, 24, 45, 0.94), rgba(3, 10, 22, 0.96)),
     #07101e;
@@ -194,6 +194,36 @@
   box-shadow:
     0 0 0 1px rgba(115, 84, 255, 0.18),
     0 28px 70px rgba(0, 0, 0, 0.38);
+}
+
+.codePanel code {
+  display: block;
+}
+
+.codeLine {
+  display: block;
+  min-height: 1.65em;
+}
+
+.keyword {
+  color: #8f7dff;
+}
+
+.namespace,
+.type {
+  color: #45c0ff;
+}
+
+.attribute {
+  color: #56e39f;
+}
+
+.property {
+  color: #f5d76e;
+}
+
+.method {
+  color: #7de5ff;
 }
 
 .homeAssistantBadge {

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -1,36 +1,450 @@
-/* stylelint-disable docusaurus/copyright-header */
-/**
- * CSS files with the .module.css suffix will be treated as CSS modules
- * and scoped locally.
- */
+.pageShell {
+  --nd-text: #f5f8ff;
+  --nd-text-muted: #c2cade;
+  --nd-text-soft: #96a2bb;
 
-.heroBanner {
-  padding: 4rem 0;
-  text-align: center;
-  position: relative;
+  min-height: calc(100vh - var(--ifm-navbar-height));
+  padding: 1.75rem clamp(1rem, 4vw, 4.5rem) 3rem;
+  color: var(--nd-text);
+  background:
+    radial-gradient(circle at 82% 26%, rgba(125, 69, 255, 0.24), transparent 28rem),
+    radial-gradient(circle at 58% 16%, rgba(28, 170, 255, 0.17), transparent 24rem),
+    linear-gradient(180deg, #020712 0%, #071224 48%, #030813 100%);
   overflow: hidden;
 }
 
-@media screen and (max-width: 966px) {
-  .heroBanner {
-    padding: 2rem;
-  }
+.hero {
+  position: relative;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 1rem 0 2rem;
 }
 
-.buttons {
+.hero::before {
+  position: absolute;
+  inset: 6rem -8rem auto 30%;
+  height: 26rem;
+  pointer-events: none;
+  content: '';
+  background-image:
+    linear-gradient(rgba(73, 154, 255, 0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(73, 154, 255, 0.12) 1px, transparent 1px);
+  background-size: 34px 34px;
+  mask-image: radial-gradient(circle, #000 0%, transparent 72%);
+}
+
+.heroGlow {
+  position: absolute;
+  right: 0;
+  bottom: -4rem;
+  width: 28rem;
+  height: 18rem;
+  pointer-events: none;
+  background: radial-gradient(circle, rgba(120, 72, 255, 0.36), transparent 68%);
+  filter: blur(10px);
+}
+
+.heroNavBrand {
+  display: inline-flex;
+  gap: 0.75rem;
+  align-items: center;
+  margin-bottom: clamp(3rem, 7vw, 6rem);
+  font-size: 1.6rem;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.heroNavBrand img {
+  width: 3.25rem;
+  height: 3.25rem;
+}
+
+.heroGrid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(24rem, 0.82fr);
+  gap: clamp(2rem, 5vw, 5rem);
+  align-items: center;
+}
+
+.heroContent {
+  max-width: 42rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.85rem;
+  padding: 0.25rem 0.85rem;
+  margin-bottom: 1.7rem;
+  color: #45c0ff;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  background: rgba(23, 126, 255, 0.18);
+  border: 1px solid rgba(62, 171, 255, 0.22);
+  border-radius: 999px;
+}
+
+.heroContent h1 {
+  max-width: 48rem;
+  margin: 0;
+  font-size: clamp(3.25rem, 6vw, 5.75rem);
+  line-height: 1.08;
+  letter-spacing: 0;
+}
+
+.heroContent h1 span {
+  color: #7c61ff;
+  text-shadow: 0 0 28px rgba(103, 91, 255, 0.72);
+}
+
+.lede {
+  max-width: 42rem;
+  margin: 1.6rem 0 2.35rem;
+  color: var(--nd-text-muted);
+  font-size: 1.25rem;
+  line-height: 1.65;
+}
+
+.heroActions {
   display: flex;
+  flex-wrap: wrap;
+  gap: 1.1rem;
+}
+
+.button {
+  display: inline-flex;
+  gap: 0.75rem;
   align-items: center;
   justify-content: center;
+  min-height: 3.75rem;
+  padding: 0.95rem 1.9rem;
+  color: var(--nd-text);
+  font-weight: 700;
+  text-decoration: none;
+  border-radius: 8px;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.button:hover {
+  color: #fff;
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #1687ff 0%, #7648ff 100%);
+  box-shadow: 0 14px 34px rgba(56, 103, 255, 0.38);
+}
+
+.secondaryButton {
+  color: #41c0ff;
+  background: rgba(7, 19, 39, 0.74);
+  border: 1px solid rgba(55, 169, 255, 0.48);
+}
+
+.secondaryButton:hover {
+  border-color: rgba(130, 98, 255, 0.8);
+  box-shadow: 0 12px 30px rgba(42, 125, 255, 0.2);
+}
+
+.codeWrap {
+  position: relative;
+  min-width: 0;
+}
+
+.codeWrap::before {
+  position: absolute;
+  inset: 12% -9% -12% 22%;
+  z-index: -1;
+  content: '';
+  background: linear-gradient(110deg, rgba(29, 160, 255, 0.18), rgba(126, 49, 255, 0.38));
+  filter: blur(34px);
+}
+
+.languagePill {
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  z-index: 2;
+  padding: 0.2rem 0.45rem;
+  color: #b7c1d9;
+  font-size: 0.8rem;
+  background: rgba(134, 151, 184, 0.12);
+  border-radius: 999px;
+}
+
+.codePanel {
+  min-height: 24rem;
+  padding: 2rem;
+  margin: 0;
+  overflow: auto;
+  color: #e9f2ff;
+  font-size: 0.92rem;
+  line-height: 1.75;
+  background:
+    linear-gradient(180deg, rgba(11, 24, 45, 0.94), rgba(3, 10, 22, 0.96)),
+    #07101e;
+  border: 1px solid rgba(60, 177, 255, 0.62);
+  border-radius: 8px;
+  box-shadow:
+    0 0 0 1px rgba(115, 84, 255, 0.18),
+    0 28px 70px rgba(0, 0, 0, 0.38);
+}
+
+.homeAssistantBadge {
+  position: absolute;
+  right: -3.4rem;
+  bottom: -2.2rem;
+  display: grid;
+  width: 8.3rem;
+  height: 8.3rem;
+  place-items: center;
+  background: linear-gradient(135deg, #28b9ff, #2274e8);
+  border-radius: 8px;
+  box-shadow: 0 18px 44px rgba(39, 139, 255, 0.42);
+}
+
+.homeAssistantBadge img {
+  width: 5.2rem;
+  height: 5.2rem;
+  object-fit: contain;
 }
 
 .features {
-  display: flex;
-  align-items: center;
-  padding: 2rem 0;
-  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  max-width: 1280px;
+  margin: 1.5rem auto 0;
 }
 
-.featureImage {
-  height: 150px;
-  width: 150px;
+.featureCard,
+.githubPanel {
+  background:
+    linear-gradient(145deg, rgba(32, 48, 82, 0.58), rgba(8, 17, 35, 0.82)),
+    rgba(8, 17, 35, 0.78);
+  border: 1px solid rgba(141, 162, 201, 0.22);
+  border-radius: 8px;
+  box-shadow: 0 22px 52px rgba(0, 0, 0, 0.23);
+}
+
+.featureCard {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.35rem;
+  min-height: 10.8rem;
+  padding: 1.8rem;
+}
+
+.featureIcon {
+  display: grid;
+  flex: 0 0 auto;
+  width: 4.75rem;
+  height: 4.75rem;
+  place-items: center;
+  color: #f199ff;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 1.6rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, rgba(122, 62, 225, 0.8), rgba(52, 36, 95, 0.9));
+  border-radius: 8px;
+}
+
+.featureIcon img {
+  width: 3.2rem;
+  height: 3.2rem;
+  object-fit: contain;
+}
+
+.featureCard h3,
+.githubPanel h2 {
+  margin: 0 0 0.7rem;
+  color: var(--nd-text);
+  font-size: 1.35rem;
+  line-height: 1.25;
+}
+
+.featureCard p,
+.githubPanel p {
+  margin: 0;
+  color: var(--nd-text-muted);
+  line-height: 1.55;
+}
+
+.githubPanel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.45fr);
+  gap: 2rem;
+  align-items: center;
+  max-width: 1280px;
+  margin: 1.5rem auto 0;
+  padding: 1.8rem 2rem;
+}
+
+.githubIntro {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.35rem;
+  align-items: center;
+}
+
+.githubMark {
+  display: grid;
+  width: 4.5rem;
+  height: 4.5rem;
+  place-items: center;
+  color: #030813;
+  font-weight: 900;
+  background: #fff;
+  border-radius: 999px;
+}
+
+.githubButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.4rem;
+  padding: 0.45rem 1rem;
+  margin-top: 0.9rem;
+  color: var(--nd-text);
+  font-size: 0.95rem;
+  font-weight: 700;
+  text-decoration: none;
+  background: rgba(146, 164, 197, 0.13);
+  border: 1px solid rgba(146, 164, 197, 0.12);
+  border-radius: 6px;
+}
+
+.githubButton:hover {
+  color: #fff;
+  text-decoration: none;
+  border-color: rgba(62, 171, 255, 0.45);
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.stat {
+  display: grid;
+  gap: 0.45rem;
+  justify-items: center;
+  padding: 0.75rem 1rem;
+  text-align: center;
+  border-left: 1px solid rgba(141, 162, 201, 0.18);
+}
+
+.stat strong {
+  color: var(--nd-text);
+  font-size: 1.65rem;
+  font-weight: 600;
+}
+
+.stat span {
+  color: var(--nd-text-soft);
+}
+
+.useCases {
+  max-width: 1280px;
+  margin: 1.4rem auto 0;
+  text-align: center;
+}
+
+.useCases p {
+  color: var(--nd-text-muted);
+  font-size: 1.05rem;
+}
+
+.useCases div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.useCases span {
+  min-width: 9.25rem;
+  padding: 0.65rem 1.2rem;
+  color: #d8e2f6;
+  background: rgba(37, 81, 150, 0.24);
+  border: 1px solid rgba(73, 120, 205, 0.16);
+  border-radius: 6px;
+}
+
+@media screen and (max-width: 996px) {
+  .heroNavBrand {
+    margin-bottom: 2.5rem;
+  }
+
+  .heroGrid,
+  .features,
+  .githubPanel {
+    grid-template-columns: 1fr;
+  }
+
+  .codePanel {
+    min-height: 20rem;
+  }
+
+  .homeAssistantBadge {
+    right: 1rem;
+    bottom: -2.7rem;
+    width: 6.5rem;
+    height: 6.5rem;
+  }
+
+  .homeAssistantBadge img {
+    width: 4rem;
+    height: 4rem;
+  }
+
+  .features {
+    margin-top: 3.5rem;
+  }
+
+  .stat:first-child {
+    border-left: 0;
+  }
+}
+
+@media screen and (max-width: 640px) {
+  .pageShell {
+    padding: 1rem 1rem 2.5rem;
+  }
+
+  .heroContent h1 {
+    font-size: 3rem;
+  }
+
+  .lede {
+    font-size: 1.05rem;
+  }
+
+  .button {
+    width: 100%;
+  }
+
+  .featureCard,
+  .githubIntro {
+    grid-template-columns: 1fr;
+  }
+
+  .statsGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .stat {
+    border-top: 1px solid rgba(141, 162, 201, 0.18);
+    border-left: 0;
+  }
+
+  .stat:first-child {
+    border-top: 0;
+  }
 }


### PR DESCRIPTION
## Summary
- Updated the homepage GitHub panel to use live NetDaemon repository stats with safe fallback values.
- Replaced the hero code sample with the requested `IHaContext` example and added theme-matched syntax highlighting with smaller typography to show better
- Restyled the footer to better match the site’s dark blue and violet visual language.
- Kept the start page and site config aligned with the current NetDaemon docs structure.

## Testing
- `yarn build` passed.
- Verified the generated homepage renders the fallback GitHub stats and the updated code sample styling.